### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,7 +169,7 @@ it, `rustfmt` will update your files locally instead.
 You can run loom tests with
 ```
 cd tokio # tokio crate in workspace
-LOOM_MAX_PREEMPTIONS=1 RUSTFLAGS="--cfg loom" \
+LOOM_MAX_PREEMPTIONS=1 RUSTFLAGS="--cfg tokio_unstable --cfg loom" \
     cargo test --lib --release --features full -- --test-threads=1 --nocapture
 ```
 


### PR DESCRIPTION
I found that I needed to pass the `tokio_unstable` `RUSTFLAG` in order to get the loom tests running so I've added it to the docs.

The error I ran into was:
```
error[E0432]: unresolved import `crate::task::JoinSet`
 --> tokio/src/runtime/tests/loom_join_set.rs:2:5
  |
2 | use crate::task::JoinSet;
  |     ^^^^^^^^^^^^^^^^^^^^ no `JoinSet` in `task`

For more information about this error, try `rustc --explain E0432`.
error: could not compile `tokio` due to previous error
```